### PR TITLE
add a little hash to the path for pngs

### DIFF
--- a/lua/ge/extensions/BeamPaint.lua
+++ b/lua/ge/extensions/BeamPaint.lua
@@ -32,9 +32,8 @@ local function BP_reportPlayerCache()
     local liveryCache = {}
     local pngs = FS:findFiles("vehicles/common/", '*.png', 0, false, false)
     for index, path in pairs(pngs) do
-        if string.match(path, "(%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x)") then --look at my regex, dawg, I'm going to jail
-            local hash = string.sub(path, 18)
-            hash = string.sub(hash, 1, 36)
+        local hash = string.match(path, "(%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x)") --look at my regex, dawg, I'm going to jail
+        if hash then
             liveryCache[index] = hash
         end
     end
@@ -47,9 +46,7 @@ end
 
 local function BP_cacheUpdateComplete(type)
     if type == "report" then
-        TriggerServerEvent("BP_clientReady", "")
-    elseif type == "update" then
-        
+        TriggerServerEvent("BP_clientReady", "") 
     end
 end
 

--- a/lua/ge/extensions/BeamPaint.lua
+++ b/lua/ge/extensions/BeamPaint.lua
@@ -45,8 +45,12 @@ local function BP_updatePlayerCache(hash)
     TriggerServerEvent("BP_cachedLiveryUpdate", hash)
 end
 
-local function BP_cacheUpdateComplete()
-    TriggerServerEvent("BP_clientReady", "")
+local function BP_cacheUpdateComplete(type)
+    if type == "report" then
+        TriggerServerEvent("BP_clientReady", "")
+    elseif type == "update" then
+        
+    end
 end
 
 local function applyLiveryAttempt()

--- a/lua/ge/extensions/BeamPaint.lua
+++ b/lua/ge/extensions/BeamPaint.lua
@@ -86,6 +86,7 @@ local function BP_markTextureComplete(json_data)
     end
     M.incompleteTextureData[tid] = ""
     table.insert(M.waitingForLivery, tidHash)
+    BP_updatePlayerCache(hash)
 end
 
 local function BP_textureSkip(json_data)
@@ -97,7 +98,6 @@ local function BP_textureSkip(json_data)
     print("Livery cached, applying now...")
     M.incompleteTextureData[tid] = ""
     table.insert(M.waitingForLivery, tidHash)
-    BP_updatePlayerCache(hash)
 end
 
 local function setLiveryUsedAttempt(objid, vehName)

--- a/lua/ge/extensions/BeamPaint.lua
+++ b/lua/ge/extensions/BeamPaint.lua
@@ -31,12 +31,13 @@ end
 local function applyLiveryAttempt()
     local tidHash = table.remove(M.waitingForLivery, 1)
     local tid = string.sub(tidHash, 1, 3)
+    local hash = string.sub(tidHash, 4)
     local objid = MPVehicleGE.getGameVehicleID(tid)
     if objid and objid ~= -1 then
         local vehicle = MPVehicleGE.getVehicleByGameID(objid)
         if vehicle.isSpawned then
             M.texMap[objid] = tidHash
-            be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. tidHash .. ".png\")")
+            be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. hash .. ".png\")")
         else
             table.insert(M.waitingForLivery, tidHash)
         end
@@ -47,10 +48,10 @@ local function BP_markTextureComplete(json_data)
     print("Received texture complete status from server...")
     local data = jsonDecode(json_data)
     local tid = data.target_id
-    local shortHash = string.sub(data.livery_id, 1, 4)
+    local hash = data.livery_id
+    local tidHash = tid .. hash
     print("Writing data to a file...")
-    local tidHash = tid .. "-" .. shortHash
-    local out = io.open("vehicles/common/" .. tidHash .. ".png", "wb")
+    local out = io.open("vehicles/common/" .. hash .. ".png", "wb")
     if out then
         out:write(M.incompleteTextureData[tid])
         out:flush()
@@ -68,8 +69,9 @@ local function setLiveryUsedAttempt(objid, vehName)
         if M.alreadySent[objid] ~= nil and M.alreadySent[objid].prevVehName == vehName then
             local tidHash = M.texMap[objid]
             local tid = string.sub(tidHash, 1, 3)
+            local hash = string.sub(tidHash, 4)
             if tid then
-                be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. tidHash .. ".png\")")
+                be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. hash .. ".png\")")
                 return false
             end
         else
@@ -88,8 +90,9 @@ local function setLiveryUsedAttempt(objid, vehName)
         local tidHash = M.texMap[objid]
         if tidHash then
             local tid = string.sub(tidHash, 1, 3)
+            local hash = string.sub(tidHash, 4)
             if tid then
-                be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. tidHash .. ".png\")")
+                be:getObjectByID(objid):queueLuaCommand("extensions.BeamPaint.updateLivery(\"" .. hash .. ".png\")")
                 return false
             end
         end

--- a/lua/ge/extensions/BeamPaint.lua
+++ b/lua/ge/extensions/BeamPaint.lua
@@ -5,6 +5,9 @@ M.dependencies = {"ui_imgui"}
 
 local im = ui_imgui
 
+local gui_module = require("ge/extensions/editor/api/gui")
+local gui = {setupEditorGuiTheme = nop}
+
 M.markedReady = false
 M.alreadySent = {}
 M.incompleteTextureData = {}
@@ -220,11 +223,39 @@ local function init()
             end
         end
     end
+	gui_module.initialize(gui)
+	gui.registerWindow("BeamPaint", im.ImVec2(512, 256))
+	gui.showWindow("BeamPaint")
 end
 
 local function onUiChangedState(state)
     M.inVehicleConfigMenu = state == "menu.vehicleconfig.parts"
     M.inVehiclePaintMenu = state == "menu.vehicleconfig.color"
+end
+
+local function drawBP()
+    gui.setupWindow("BeamPaint")
+	im.PushStyleColor2(im.Col_Button, im.ImVec4(0.85, 0.15, 0.75, 0.333))
+	im.PushStyleColor2(im.Col_ButtonHovered, im.ImVec4(0.8, 0.1, 0.69, 0.5))
+	im.PushStyleColor2(im.Col_ButtonActive, im.ImVec4(0.75, 0.05, 0.55, 0.999))
+    im.Begin("BeamPaint", im.BoolPtr(true), im.WindowFlags_AlwaysAutoResize)
+        if im.Button("Reload Livery") then
+            reloadLivery()
+        end
+        if M.singlePlayer then
+            im.Separator()
+            im.Text("Liveries are loaded from <userfolder>/vehicles/common/<vehName>.png!")
+            im.Text("To preview a livery, place it there with the following name and hit \"Reload Livery\".")
+            local vehName = be:getPlayerVehicle(0):getField("JBeam", 0)
+            im.Text("For the current vehicle: \"/vehicles/common/" .. vehName .. ".png\"")
+            if im.Button("Open folder...") then
+                Engine.Platform.exploreFolder("/vehicles/common/")
+            end
+        else
+            -- TODO: Show current livery?
+        end
+        im.PopStyleColor(3)
+    im.End()
 end
 
 local function onUpdate(dt)
@@ -255,23 +286,7 @@ local function onUpdate(dt)
     end
     if M.inVehicleConfigMenu then
         -- Show the "Reload livery" UI
-        if im.Begin("BeamPaint", im.BoolPtr(true), im.WindowFlags_AlwaysAutoResize) then
-            if im.Button("Reload Livery") then
-                reloadLivery()
-            end
-            if M.singlePlayer then
-                im.Separator()
-                im.Text("Liveries are loaded from /vehicles/common/<vehName>.png!")
-                im.Text("If you want to preview a livery, simply put it in there with the right name and hit \"Reload Livery\".")
-                local vehName = be:getPlayerVehicle(0):getField("JBeam", 0)
-                im.Text("For the current vehicle: \"/vehicles/common/" .. vehName .. ".png\"")
-                if im.Button("Open folder...") then
-                    Engine.Platform.exploreFolder("/vehicles/common/")
-                end
-            else
-                -- TODO: Show current livery?
-            end
-        end
+        drawBP()
     end
 end
 

--- a/lua/ge/extensions/BeamPaint.lua
+++ b/lua/ge/extensions/BeamPaint.lua
@@ -33,7 +33,7 @@ local function BP_reportPlayerCache()
     local pngs = FS:findFiles("vehicles/common/", '*.png', 0, false, false)
     for index, path in pairs(pngs) do
         if string.match(path, "(%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x)") then --look at my regex, dawg, I'm going to jail
-            local hash = string.sub(v, 18)
+            local hash = string.sub(path, 18)
             hash = string.sub(hash, 1, 36)
             liveryCache[index] = hash
         end


### PR DESCRIPTION
prevents the condition in which old liveries are applied to new vehicles

(and a sneaky final [please god{no but for real I got it}] log spam fix)

Designed to go with the BeamPaint server PR I'm about to open